### PR TITLE
Allow global counters to trigger state changes

### DIFF
--- a/examples/pybpodapi/state_machine_examples/global_counter_example.py
+++ b/examples/pybpodapi/state_machine_examples/global_counter_example.py
@@ -32,14 +32,20 @@ sma.add_state(
 sma.add_state(
 	state_name='Port1Lit',  # Infinite loop (with next state). Only a global counter can save us.
 	state_timer=.25,
-	state_change_conditions={Bpod.Events.Tup: 'Port3Lit', 'GlobalCounter1_End': 'exit'},
+	state_change_conditions={Bpod.Events.Tup: 'Port3Lit', 'GlobalCounter1_End': 'ExitTask'},
 	output_actions=[(Bpod.OutputChannels.PWM1, 255)])
 
 sma.add_state(
 	state_name='Port3Lit',
 	state_timer=.25,
-	state_change_conditions={Bpod.Events.Tup: 'Port1Lit', 'GlobalCounter1_End': 'exit'},
+	state_change_conditions={Bpod.Events.Tup: 'Port1Lit', 'GlobalCounter1_End': 'ExitTask'},
 	output_actions=[(Bpod.OutputChannels.PWM3, 255)])
+
+sma.add_state(
+	state_name='ExitTask',
+	state_timer=.25,
+	state_change_conditions={Bpod.Events.Tup: 'exit'},
+)
 
 my_bpod.send_state_machine(sma)
 

--- a/src/pybpodapi/bpod/bpod_base.py
+++ b/src/pybpodapi/bpod/bpod_base.py
@@ -543,6 +543,21 @@ class BpodBase(object):
                                     state_change_indexes.append(len(current_trial.events_occurrences) - 1)
                                 transition_event_found = True
 
+                    # global counters matrix
+                    if not transition_event_found:
+                        for transition in sma.global_counters.matrix[sma.current_state]:
+                            if transition[0] == event_id:
+                                if sma.use_255_back_signal and transition[1] == 255:
+                                    sma.current_state = current_trial.states[-2]
+                                else:
+                                    sma.current_state = transition[1]
+
+                                if not math.isnan(sma.current_state):
+                                    logger.debug("adding states global counters matrix")
+                                    current_trial.states.append(sma.current_state)
+                                    state_change_indexes.append(len(current_trial.events_occurrences) - 1)
+                                transition_event_found = True
+
                 logger.debug("States indexes: %s", current_trial.states)
 
             if transition_event_found and not math.isnan(sma.current_state):


### PR DESCRIPTION
Thanks for your awesome work with this repository.

Currently global counter events do not correctly trigger state changes. This is demonstrated in [this issue](https://github.com/int-brain-lab/iblpybpod/issues/3). 

Currently global counter end events can trigger actions in the state where they are defined as `state_change_conditions`, meaning the `global_counter_example` works currently. However if global counter end events trigger a state change, (such as in the [above issue](https://github.com/int-brain-lab/iblpybpod/issues/3) and the global_counter_example updated in this PR), this is not processed correctly. If you run the new `global_counter_example` on this branch without the change to `bpod_base`, you will see that although the task exits, the ExitTask state's start time is recorded as nan. The change to `bpod_base` fixes the issue I believe. 

Interested to hear your feedback on this and if you think there is a cleaner way to fix the bug.